### PR TITLE
Make "today" tz-aware

### DIFF
--- a/didier/cogs/school.py
+++ b/didier/cogs/school.py
@@ -16,7 +16,7 @@ from didier.exceptions import HTTPException, NotInMainGuildException
 from didier.utils.discord.converters.time import DateTransformer
 from didier.utils.discord.flags.school import StudyGuideFlags
 from didier.utils.discord.users import to_main_guild_member
-from didier.utils.types.datetime import skip_weekends
+from didier.utils.types.datetime import skip_weekends, tz_aware_today
 
 
 class School(commands.Cog):
@@ -49,7 +49,7 @@ class School(commands.Cog):
         """
         async with ctx.typing():
             if day_dt is None:
-                day_dt = date.today()
+                day_dt = tz_aware_today()
 
             day_dt = skip_weekends(day_dt)
 
@@ -78,7 +78,7 @@ class School(commands.Cog):
         Menus are shown in Dutch by default, as a lot of dishes have very weird translations.
         """
         if day_dt is None:
-            day_dt = date.today()
+            day_dt = tz_aware_today()
 
         async with ctx.typing():
             try:

--- a/didier/data/embeds/schedules.py
+++ b/didier/data/embeds/schedules.py
@@ -18,7 +18,12 @@ from database.crud.ufora_courses import get_course_by_code
 from database.schemas import UforaCourse
 from didier.data.embeds.base import EmbedBaseModel
 from didier.utils.discord import colours
-from didier.utils.types.datetime import LOCAL_TIMEZONE, int_to_weekday, time_string
+from didier.utils.types.datetime import (
+    LOCAL_TIMEZONE,
+    int_to_weekday,
+    time_string,
+    tz_aware_today,
+)
 from didier.utils.types.string import leading
 from settings import ScheduleType
 
@@ -71,7 +76,7 @@ class Schedule(EmbedBaseModel):
 
     @overrides
     def to_embed(self, **kwargs) -> discord.Embed:
-        day: date = kwargs.get("day", date.today())
+        day: date = kwargs.get("day", tz_aware_today())
         day_str = f"{leading('0', str(day.day))}/{leading('0', str(day.month))}/{leading('0', str(day.year))}"
 
         embed = discord.Embed(title=f"Schedule - {int_to_weekday(day.weekday())} {day_str}")

--- a/didier/utils/discord/converters/time.py
+++ b/didier/utils/discord/converters/time.py
@@ -13,6 +13,7 @@ from didier.utils.types.datetime import (
     forward_to_next_weekday,
     parse_dm_string,
     str_to_weekday,
+    tz_aware_today,
 )
 
 __all__ = ["date_converter", "DateTransformer"]
@@ -25,7 +26,7 @@ def date_converter(argument: Optional[str]) -> date:
 
     # Default to today
     if not argument:
-        return date.today()
+        return tz_aware_today()
 
     argument = argument.lower()
 
@@ -35,15 +36,15 @@ def date_converter(argument: Optional[str]) -> date:
         "tmrw",
         "morgen",
     ):
-        return date.today() + timedelta(days=1)
+        return tz_aware_today() + timedelta(days=1)
 
     if argument in ("overmorgen",):
-        return date.today() + timedelta(days=2)
+        return tz_aware_today() + timedelta(days=2)
 
     # Weekdays passed in words
     with contextlib.suppress(ValueError):
         weekday = str_to_weekday(argument)
-        return forward_to_next_weekday(date.today(), weekday, allow_today=False)
+        return forward_to_next_weekday(tz_aware_today(), weekday, allow_today=False)
 
     # Date strings
     with contextlib.suppress(ValueError):

--- a/didier/utils/types/datetime.py
+++ b/didier/utils/types/datetime.py
@@ -56,7 +56,7 @@ def parse_dm_string(argument: str) -> datetime.date:
     - [English Month, possibly abbreviated] DD
     """
     argument = argument.lower()
-    today = datetime.date.today()
+    today = tz_aware_today()
 
     # DD/MM
     if "/" in argument:

--- a/didier/utils/types/datetime.py
+++ b/didier/utils/types/datetime.py
@@ -14,6 +14,7 @@ __all__ = [
     "str_to_weekday",
     "time_string",
     "tz_aware_now",
+    "tz_aware_today",
 ]
 
 DateType = TypeVar("DateType", datetime.date, datetime.datetime)
@@ -187,3 +188,8 @@ def time_string(dt_instance: datetime.datetime) -> str:
 def tz_aware_now() -> datetime.datetime:
     """Get the current date & time, but timezone-aware"""
     return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).astimezone(LOCAL_TIMEZONE)
+
+
+def tz_aware_today() -> datetime.date:
+    """Get the current day, but timezone-aware"""
+    return tz_aware_now().date()


### PR DESCRIPTION
The default value for commands that use dates is now timezone-aware to account for an issue on the Pi