### PR TITLE
Fix db script runner

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -32,7 +32,7 @@ max-line-length = 120
 # Disable some rules for entire files
 per-file-ignores =
     # DALL000: Missing __all__, main isn't supposed to be imported
-    main.py: DALL000,
+    main.py: DALL000, run_db_scripts.py: DALL000,
     # DALL000: Missing __all__, Cogs aren't modules
     ./didier/cogs/*: DALL000,
     # DALL000: Missing __all__, tests aren't supposed to be imported

--- a/run_db_scripts.py
+++ b/run_db_scripts.py
@@ -8,7 +8,9 @@ import importlib
 import sys
 from typing import Callable
 
-if __name__ == "__main__":
+
+async def main():
+    """Try to parse all command-line arguments into modules and run them sequentially"""
     scripts = sys.argv[1:]
     if not scripts:
         print("No scripts provided.", file=sys.stderr)
@@ -20,8 +22,12 @@ if __name__ == "__main__":
 
         try:
             script_main: Callable = module.main
-            asyncio.run(script_main())
+            await script_main()
             print(f"Successfully ran {script}")
         except AttributeError:
             print(f'Script "{script}" not found.', file=sys.stderr)
             exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Only one `asyncio.run()` call should be used per script. Use it to run the main loop, and `await` the scripts in there.