### PR TITLE
Load calendars on startup & disable task

### DIFF
--- a/didier/cogs/tasks.py
+++ b/didier/cogs/tasks.py
@@ -63,7 +63,7 @@ class Tasks(commands.Cog):
         if settings.BIRTHDAY_ANNOUNCEMENT_CHANNEL is not None:
             self.check_birthdays.start()
 
-        # Only pull free gmaes if a channel was provided
+        # Only pull free games if a channel was provided
         if settings.FREE_GAMES_CHANNEL is not None:
             self.pull_free_games.start()
 
@@ -73,10 +73,8 @@ class Tasks(commands.Cog):
             self.remove_old_ufora_announcements.start()
 
         # Start other tasks
-        self.init_schedules.start()
         self.reminders.start()
         self.reset_wordle_word.start()
-        self.pull_schedules.start()
 
     @overrides
     def cog_unload(self) -> None:
@@ -133,16 +131,6 @@ class Tasks(commands.Cog):
 
     @check_birthdays.before_loop
     async def _before_check_birthdays(self):
-        await self.client.wait_until_ready()
-
-    @tasks.loop(count=1)
-    async def init_schedules(self, **kwargs):
-        """Tasks that loads the schedules in memory on startup"""
-        _ = kwargs
-        await self.client.load_schedules()
-
-    @init_schedules.before_loop
-    async def _before_init_schedules(self):
         await self.client.wait_until_ready()
 
     @tasks.loop(minutes=15)

--- a/didier/didier.py
+++ b/didier/didier.py
@@ -7,7 +7,6 @@ from typing import Optional, Union
 
 import discord
 from aiohttp import ClientSession
-from discord.app_commands import AppCommandError
 from discord.ext import commands
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -246,7 +245,7 @@ class Didier(commands.Bot):
         async with self.postgres_session as session:
             await command_stats.register_command_invocation(session, ctx, command, tz_aware_now())
 
-    async def on_app_command_error(self, interaction: discord.Interaction, exception: AppCommandError):
+    async def on_app_command_error(self, interaction: discord.Interaction, exception: Exception):
         """Event triggered when an application command errors"""
         # If commands have their own error handler, let it handle the error instead
         if hasattr(interaction.command, "on_error"):

--- a/didier/didier.py
+++ b/didier/didier.py
@@ -252,11 +252,22 @@ class Didier(commands.Bot):
         if hasattr(interaction.command, "on_error"):
             return
 
-        if isinstance(exception, (NoMatch, discord.app_commands.CommandInvokeError)):
+        # Unwrap exception
+        if isinstance(exception, discord.app_commands.CommandInvokeError):
+            exception = exception.original
+
+        if isinstance(exception, (NoMatch, HTTPException)):
             if interaction.response.is_done():
-                return await interaction.response.send_message(str(exception.original), ephemeral=True)
+                return await interaction.response.send_message(str(exception), ephemeral=True)
             else:
-                return await interaction.followup.send(str(exception.original), ephemeral=True)
+                return await interaction.followup.send(str(exception), ephemeral=True)
+
+        await interaction.response.send_message("Something went wrong processing this command.", ephemeral=True)
+
+        if settings.ERRORS_CHANNEL is not None:
+            embed = create_error_embed(await commands.Context.from_interaction(interaction), exception)
+            channel = self.get_channel(settings.ERRORS_CHANNEL)
+            await channel.send(embed=embed)
 
     async def on_command_completion(self, ctx: commands.Context):
         """Event triggered when a message command completes successfully"""
@@ -279,6 +290,10 @@ class Didier(commands.Bot):
         if hasattr(ctx.command, "on_error"):
             return
 
+        # Hybrid command errors are wrapped in an additional error, so wrap it back out
+        if isinstance(exception, commands.HybridCommandError):
+            exception = exception.original
+
         # Ignore exceptions that aren't important
         if isinstance(
             exception,
@@ -291,7 +306,10 @@ class Didier(commands.Bot):
             return
 
         # Responses to things that go wrong during processing of commands
-        if isinstance(exception, commands.CommandInvokeError) and isinstance(
+        if isinstance(
+            exception,
+            (discord.app_commands.CommandInvokeError, commands.CommandInvokeError),
+        ) and isinstance(
             exception.original,
             (
                 NoMatch,

--- a/main.py
+++ b/main.py
@@ -11,6 +11,10 @@ from didier import Didier
 async def run_bot():
     """Run Didier"""
     didier = Didier()
+
+    # Schedules are quite heavy - do this once before connecting
+    await didier.load_schedules()
+
     try:
         await didier.start(settings.DISCORD_TOKEN)
     finally:


### PR DESCRIPTION
The calendar loading task was quite heavy & caused some connectivity issues. As the link never updates anyways (unsurprisingly :s) there's no use doing it over and over. The calendars can be loaded in once on startup and then never again. This happens before connecting to Discord, to prevent blocking the socket.