### PR TITLE
Re-write Mock

### DIFF
--- a/didier/cogs/fun.py
+++ b/didier/cogs/fun.py
@@ -150,13 +150,13 @@ class Fun(commands.Cog):
         if len(message) > constants.Limits.MESSAGE_LENGTH:
             return await interaction.followup.send("That message is too long.")
 
-        mocked_message = mock(discord.utils.escape_markdown(message))
+        message = discord.utils.escape_markdown(message)
 
         # Escaping md syntax can make the message longer than the limit
-        if len(mocked_message) > constants.Limits.MESSAGE_LENGTH:
+        if len(message) > constants.Limits.MESSAGE_LENGTH:
             return await interaction.followup.send("Because of Markdown syntax escaping, that message is too long.")
 
-        return await interaction.followup.send(mocked_message)
+        return await interaction.followup.send(mock(message))
 
     @commands.hybrid_command(name="xkcd")
     @app_commands.rename(comic_id="id")

--- a/didier/utils/types/string.py
+++ b/didier/utils/types/string.py
@@ -1,8 +1,9 @@
 import math
+import random
 import re
 from typing import Optional, Union
 
-__all__ = ["abbreviate", "leading", "pluralize", "re_find_all", "re_replace_with_list", "get_edu_year_name"]
+__all__ = ["abbreviate", "leading", "mock", "pluralize", "re_find_all", "re_replace_with_list", "get_edu_year_name"]
 
 
 def abbreviate(text: str, max_length: int) -> str:
@@ -36,6 +37,28 @@ def leading(character: str, string: str, target_length: Optional[int] = 2) -> st
     frequency = math.ceil((target_length - len(string)) / len(character))
 
     return (frequency * character) + string
+
+
+def mock(string: str) -> str:
+    """Mock an input string
+
+    The result of this is comparable to the Mocking Spongebob memes
+    """
+    replacements = {"a": "4", "b": "8", "e": "3", "i": "1", "o": "0", "s": "5"}
+    result_string = ""
+
+    for letter in string.lower():
+        # Letter should be mocked
+        if letter.isalpha() and random.random() < 0.5:
+            # Use replacement if it exists
+            if letter in replacements and random.random() < 0.5:
+                result_string += replacements[letter]
+            else:
+                result_string += letter.upper()
+        else:
+            result_string += letter
+
+    return result_string
 
 
 def pluralize(word: str, amount: int, plural_form: Optional[str] = None) -> str:


### PR DESCRIPTION
- Respond ephemerally so that the user can copy-paste the message instead of having Didier send it in public chat
- Escape Markdown syntax so you can mock a message & copy-paste the Markdown along with it